### PR TITLE
Update rmt-client-setup-res

### DIFF
--- a/public/tools/rmt-client-setup-res
+++ b/public/tools/rmt-client-setup-res
@@ -81,8 +81,15 @@ if [ ! -x $CURL ]; then
     exit 1
 fi
 
+echo "Importing repomd.xml.key"
 $RPM --import ${REGURL}/repo/SUSE/Updates/RES/8/x86_64/update/repodata/repomd.xml.key
 
+echo "Disabling all repositories"
+sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/*
+
+# Workaround for CentOS, This file is regular file on CentOS, but directory in RHEL or Liberty
+rm -f /usr/share/redhat-release
+  
 if [ ! -x $SUSECONNECT ]; then
     echo "Downloading SUSEConnect"
 
@@ -93,18 +100,10 @@ if [ ! -x $SUSECONNECT ]; then
 
     $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/RES/8/x86_64/update
     $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/RES-AS/8/x86_64/update
-    $DNF install ${AUTOACCEPT} SUSEConnect sles_es-release librepo-1.9.2
+    $DNF install ${AUTOACCEPT} --allowerasing sles_es-release
+    $DNF install ${AUTOACCEPT} SUSEConnect librepo
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_RES_8_x86_64_update"
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_RES-AS_8_x86_64_update"
-fi
-
-#iso we ship has old version of librepo installed that doesn't handle tokens in url properly
-TMP=`rpm -q librepo`;
-
-if [ $TMP = "librepo-1.9.2-1.el8.x86_64" ]; then
-   $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/RES/8/x86_64/update
-   $DNF update ${AUTOACCEPT} librepo
-   $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_RES_8_x86_64_update"
 fi
 
 $CURL -s -S $REGURL/tools/rmt-client-setup --output rmt-client-setup


### PR DESCRIPTION
Made the script work on CentOS (bsc#1197038)

## Description

rmt-client-setup-script was originally tested on RHEL and RES.This patch make it work on CentOS.
Get rid of obsolete code (workaround for librepo < 1.9.2)

Fixes # (issue)

## Change Type

*Please select the correct option.*

- [ x] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)

## Checklist

*Please check off each item if the requirement is met.*

- [  ] I have verified that my code follows RMT's coding standards with `rubocop`.
- [ x] I have reviewed my own code and believe that it's ready for an external review.
- [ x] I have provided comments for any hard-to-understand code.
- [  ] I have documented the `MANUAL.md` file with any changes to the user experience.
- [ x] RMT's test coverage remains at 100%.
- [ ] If my changes are non-trivial, I have added a changelog entry to notify users at `package/obs/rmt-server.changes`.

## Other Notes

Please use this space to provide notes or thoughts to the team, such as tips on how to review/demo your changes.
